### PR TITLE
58 authenticated users security

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,7 @@ class UsersController < ApplicationController
   end
 
   def show
+    render file: 'app/views/errors/not_found.html.erb' unless current_user
   end
 
   private

--- a/spec/features/users/user_can_create_account_spec.rb
+++ b/spec/features/users/user_can_create_account_spec.rb
@@ -2,13 +2,9 @@ require 'rails_helper'
 
 describe "When user clicks create account" do
   scenario "they are able to create an account" do
-    # visit login_path
-    #
-    # click_on "Create Account"
-    #
-    # expect(current_path).to eq(new_user_path)
-
-    visit new_user_path
+    visit login_path
+    click_on "Create Account"
+    expect(current_path).to eq(new_user_path)
 
     fill_in "user[first_name]", :with => "Charlotte"
     fill_in "user[last_name]", :with => "Moore"

--- a/spec/features/users/user_can_login_spec.rb
+++ b/spec/features/users/user_can_login_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
-
-describe "user can loggin" do
-  it "when nthey login" do
+describe "user can log in" do
+  it "when they login" do
     user = User.create(first_name: "Charlotte",
                        last_name: "Moore",
                        username: "Cj",
@@ -22,5 +21,40 @@ describe "user can loggin" do
     expect(page).to have_content("Moore")
     expect(page).to have_content("Cj")
     expect(page).to have_content("email@email.com")
+  end
+
+  it "and can only see their own data" do
+    user_two = User.create(first_name: "Charlotte",
+                           last_name: "Moore",
+                           username: "Cj",
+                           email: "email@email.com",
+                           password: "password")
+    admin_user = User.create(first_name: "Courtney",
+                             last_name: "Meyerhofer",
+                             username: "pudding",
+                             email: "anon@anon.com",
+                             password: "password",
+                             role: 1)
+
+    authenticated_user = Fabricate(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(authenticated_user)
+
+    visit dashboard_path
+    within(".card-title") do
+      expect(page).to have_content(authenticated_user.first_name)
+      expect(page).to_not have_content("Charlotte")
+    end
+
+    within(".card-content ul") do
+      expect(page).to have_content(authenticated_user.username)
+      expect(page).to have_content(authenticated_user.email)
+      expect(page).to_not have_content("email@email.com")
+      expect(page).to_not have_content("Cj")
+    end
+
+    visit admin_dashboard_path
+    within("h1") do
+      expect(page).to have_content("Error: 404 page not found")
+    end
   end
 end

--- a/spec/features/users/user_can_login_spec.rb
+++ b/spec/features/users/user_can_login_spec.rb
@@ -55,6 +55,7 @@ describe "user can log in" do
     visit admin_dashboard_path
     within("h1") do
       expect(page).to have_content("Error: 404 page not found")
+      expect(page).to_not have_content("Admin Dashboard")
     end
   end
 end

--- a/spec/features/users/visitor_cannot_see_user_admin_info_spec.rb
+++ b/spec/features/users/visitor_cannot_see_user_admin_info_spec.rb
@@ -14,6 +14,8 @@ describe "an unauthenticated user visiting the site" do
                                        username: "pudding",
                                        email: "anon@anon.com",
                                        password: "password")
+    admin_user = Fabricate(:user).admin!
+    
     visit admin_dashboard_path
     within("h1") do
       expect(page).to have_content("Error: 404 page not found")
@@ -24,16 +26,12 @@ describe "an unauthenticated user visiting the site" do
     within("h1") do
       expect(page).to have_content("Error: 404 page not found")
     end
-    within(".card-title") do
-      expect(page).to_not have_content("Charlotte")
-      expect(page).to_not have_content("Courtney")
-    end
 
-    within(".card-content ul") do
-      expect(page).to_not have_content("email@email.com")
-      expect(page).to_not have_content("Cj")
-      expect(page).to_not have_content("anon@anon.com")
-      expect(page).to_not have_content("pudding")
-    end
+    expect(page).to_not have_content("Charlotte")
+    expect(page).to_not have_content("Courtney")
+    expect(page).to_not have_content("email@email.com")
+    expect(page).to_not have_content("Cj")
+    expect(page).to_not have_content("anon@anon.com")
+    expect(page).to_not have_content("pudding")
   end
 end

--- a/spec/features/users/visitor_cannot_see_user_admin_info_spec.rb
+++ b/spec/features/users/visitor_cannot_see_user_admin_info_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+# I cannot view another user's private data, such as current order, etc.
+# I should be redirected to login/create account when I try to check out.
+describe "an unauthenticated user visiting the site" do
+  it "cannot view another user's data" do
+    user_two = User.create(first_name: "Charlotte",
+                           last_name: "Moore",
+                           username: "Cj",
+                           email: "email@email.com",
+                           password: "password")
+    unauthenticated_user = User.create(first_name: "Courtney",
+                                       last_name: "Meyerhofer",
+                                       username: "pudding",
+                                       email: "anon@anon.com",
+                                       password: "password")
+    visit admin_dashboard_path
+    within("h1") do
+      expect(page).to have_content("Error: 404 page not found")
+      expect(page).to_not have_content("Admin Dashboard")
+    end
+
+    visit dashboard_path
+    within("h1") do
+      expect(page).to have_content("Error: 404 page not found")
+    end
+    within(".card-title") do
+      expect(page).to_not have_content("Charlotte")
+      expect(page).to_not have_content("Courtney")
+    end
+
+    within(".card-content ul") do
+      expect(page).to_not have_content("email@email.com")
+      expect(page).to_not have_content("Cj")
+      expect(page).to_not have_content("anon@anon.com")
+      expect(page).to_not have_content("pudding")
+    end
+  end
+end


### PR DESCRIPTION
* closes #58 
* closes #59 

Adds sad path tests for authenticated & unauthenticated users trying to view another user's information or the admin dashboard.

One thing I'd like feedback on:
Both stories include ` I cannot make myself an admin`.
I'm not sure how to test for this. I don't know what to check here. I think we implicitly have this, but not sure if we need to test explicitly.

@Carmer @s-espinosa any thoughts about this?

All tests pass