### PR TITLE
adds category dropdown functionality, links all working

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :set_cart
-
+  before_action :define_categories
   helper_method :current_user,
                 :current_admin?
 
@@ -20,4 +20,9 @@ class ApplicationController < ActionController::Base
   def admin_login
     redirect_to admin_dashboard_path if current_admin?
   end
+
+  def define_categories
+    @categories = Category.all
+  end
+
 end

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,8 +1,16 @@
+<ul id="dropdown1" class="dropdown-content">
+  <% @categories.each do |category| %>
+    <li><%= link_to category.name, category_path(category.slug) %></li>
+    <li class="divider"></li>
+  <% end %>
+</ul>
+
 <nav>
    <div class="nav-wrapper orange darken-3">
      <div class ="container">
        <a href="<%= root_path %>" class="brand-logo">Weasleys' Wizard Wheezes</a>
        <ul id="nav-mobile" class="right hide-on-med-and-down">
+         <li><a class="dropdown-button" href="/" data-activates="dropdown1">Products</a></li>
           <li>
             <% unless @cart.total_count.nil?  %>
               <a href="/cart" class="cart-nav">Cart<span class="badge purple circle white-text"><%= @cart.total_count %></span></a></li>


### PR DESCRIPTION
👍 
- Adds product dropdown for categories to the navbar on all pages 
- Adds before_action to application controller that defines @categories 
- Links function - discovered that for category_path instead of passing through category, it requires passing category.slug 
❓ 
- When you click on "products" the drop down covers up what was originally on the nav bar - do we care? 
- I put a dividing line between each category but we don't necessarily need it

Next steps: 
- Styling the dropdown, right now it's just the materialize default